### PR TITLE
add optional tor_cmd param for Tor not on PATH

### DIFF
--- a/torrequest.py
+++ b/torrequest.py
@@ -11,10 +11,12 @@ class TorRequest(object):
   def __init__(self, 
       proxy_port=9050, 
       ctrl_port=9051,
-      password=None):
+      password=None,
+      tor_cmd='tor'):
 
     self.proxy_port = proxy_port
     self.ctrl_port = ctrl_port
+    self.tor_cmd = tor_cmd
     
     self._tor_proc = None
     if not self._tor_process_exists():
@@ -43,6 +45,7 @@ class TorRequest(object):
         'SocksPort': str(self.proxy_port),
         'ControlPort': str(self.ctrl_port)
       },
+      tor_cmd=self.tor_cmd,
       take_ownership=True)
 
   def close(self):


### PR DESCRIPTION
When I tried to use torrequest, it crashed:

    requester = torrequest.TorRequest()
    Traceback (most recent call last):
    ....
    OSError: 'tor' isn't available on your system. Maybe it's not in your PATH?

When torrequest calls `stem.process.launch_tor_with_config`, it does not specify a `tor_cmd` param; so, the default value `'tor'` is used.  I have Tor, but it's not on the PATH and never will be (because an anonymous person on the internet said that would be a security risk).

By adding this optional param for TorRequest, other users in my situation should be able to use the class much more easily by specifying `tor_cmd='path/to/tor/folder/TorBrowser/Tor/tor.exe'` for example.