### PR TITLE
Fix socks5 to use server not local

### DIFF
--- a/torrequest.py
+++ b/torrequest.py
@@ -25,8 +25,8 @@ class TorRequest(object):
 
     self.session = requests.Session()
     self.session.proxies.update({
-      'http': 'socks5://localhost:%d' % self.proxy_port,
-      'https': 'socks5://localhost:%d' % self.proxy_port,
+      'http': 'socks5h://localhost:%d' % self.proxy_port,
+      'https': 'socks5h://localhost:%d' % self.proxy_port,
     })
 
   def _tor_process_exists(self):


### PR DESCRIPTION
I don't know anything about netwotking, but as it was pointed out [here](https://github.com/erdiaker/torrequest/issues/17#issuecomment-833017075) by @SheldonPatnett there is an error that causes the request to not use Tor and exposes user's IP adress